### PR TITLE
Normalize Strapi v4 responses

### DIFF
--- a/src/app/componentes/basicos/acordeon/acordeonByID.js
+++ b/src/app/componentes/basicos/acordeon/acordeonByID.js
@@ -1,4 +1,5 @@
 import { API_URL } from "@/app/config";
+import { normalizeStrapiData } from "@/app/lib/api";
 
 // Obtiene los textos del acordeón según el ID proporcionado
 export async function getAcordeonByAcordeonID(acordeonID) {
@@ -11,12 +12,13 @@ export async function getAcordeonByAcordeonID(acordeonID) {
     }
 
     const { data } = await response.json();
+    const acordeones = normalizeStrapiData(data);
+    const acordeon = Array.isArray(acordeones) ? acordeones[0] : acordeones;
 
-    // Devuelve los textos del primer resultado (estructura esperada del backend)
-    return data[0].textos || null;
+    return Array.isArray(acordeon?.textos) ? acordeon.textos : [];
 
   } catch (error) {
     console.error('Error al obtener acordeon:', error);
-    return null; // Devuelve null en caso de error
+    return []; // Devuelve array vacío en caso de error
   }
 }

--- a/src/app/componentes/basicos/agenda.js
+++ b/src/app/componentes/basicos/agenda.js
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { API_URL } from "@/app/config";
+import { normalizeStrapiData, toAbsoluteURL } from "@/app/lib/api";
 import Slider from 'react-slick'; // Librería para carruseles
 import ReactMarkdown from 'react-markdown'; // Para renderizar texto con formato Markdown
 import { FaArrowLeft, FaArrowRight } from 'react-icons/fa'; // Íconos de flechas
@@ -40,7 +41,7 @@ export default function Agenda() {
         }
 
         const { data } = await res.json(); // Extrae los datos del JSON
-        setAgendas(data); // Almacena los datos en el estado
+        setAgendas(normalizeStrapiData(data)); // Almacena los datos en el estado
       } catch (err) {
         console.error("Error en getAgendas:", err);
       }
@@ -91,7 +92,10 @@ export default function Agenda() {
         <Slider ref={sliderRef} {...settings}>
           {agendas.map((item) => {
             const { id, tituloActividad, contenidoActividad, fecha, imagen } = item;
-            const imageUrl = imagen.url;
+            const imageUrl =
+              toAbsoluteURL(imagen?.url) ||
+              toAbsoluteURL(imagen?.formats?.medium?.url) ||
+              toAbsoluteURL(imagen?.formats?.thumbnail?.url);
 
             return (
               <div key={id} className="agenda-container">

--- a/src/app/componentes/basicos/imagen/imagenByID.js
+++ b/src/app/componentes/basicos/imagen/imagenByID.js
@@ -1,4 +1,5 @@
 import { API_URL } from "@/app/config";
+import { normalizeStrapiData, toAbsoluteURL } from "@/app/lib/api";
 
 // Obtiene la URL de una imagen a partir de su imagenID
 export async function getImagenbyImagenID(ImagenID) {
@@ -10,8 +11,15 @@ export async function getImagenbyImagenID(ImagenID) {
     }
     
     const { data } = await response.json();
+    const imagenes = normalizeStrapiData(data);
+    const imagen = Array.isArray(imagenes) ? imagenes[0]?.imagen : imagenes?.imagen;
 
-    return data[0].imagen.formats.thumbnail.url || null; // Devuelve la URL si existe
+    const url =
+      toAbsoluteURL(imagen?.formats?.thumbnail?.url) ||
+      toAbsoluteURL(imagen?.formats?.medium?.url) ||
+      toAbsoluteURL(imagen?.url);
+
+    return url || null; // Devuelve la URL si existe
   } catch (error) {
     console.error('Error al obtener la imagen:', error);
     return null; // En caso de error devuelve null

--- a/src/app/componentes/basicos/texto/text.js
+++ b/src/app/componentes/basicos/texto/text.js
@@ -35,9 +35,10 @@ export const Texto = ({ textoID }) => {
             setStatus('loading');
             try {
                 const result = await getTextoByTextoId(textoID);
-                if (result) {
-                    setTexto(result);
-                    setEditedText(result);
+                if (result && typeof result === 'object' && 'contenido' in result) {
+                    const contenido = result.contenido ?? '';
+                    setTexto(contenido);
+                    setEditedText(contenido);
                     setStatus('success');
                 } else {
                     setStatus('error');
@@ -72,9 +73,10 @@ export const Texto = ({ textoID }) => {
 
             // Recarga el contenido actualizado desde el servidor
             const result = await getTextoByTextoId(textoID);
-            if (result) {
-                setTexto(result);
-                setEditedText(result);
+            if (result && typeof result === 'object' && 'contenido' in result) {
+                const contenido = result.contenido ?? '';
+                setTexto(contenido);
+                setEditedText(contenido);
             }
 
             setIsEditing(false); // Cierra modo edición

--- a/src/app/componentes/basicos/texto/textoById.js
+++ b/src/app/componentes/basicos/texto/textoById.js
@@ -1,4 +1,5 @@
 import { API_URL } from "@/app/config";
+import { normalizeStrapiData } from "@/app/lib/api";
 
 // Función que obtiene un texto desde la API a partir de su textoID
 export async function getTextoByTextoId(textoID) {
@@ -11,9 +12,10 @@ export async function getTextoByTextoId(textoID) {
     }
 
     const { data } = await res.json();
+    const textos = normalizeStrapiData(data);
+    const texto = Array.isArray(textos) ? textos[0] : textos;
 
-    // Devuelve el contenido del primer resultado si existe
-    return data[0]?.contenido || null;
+    return texto || null;
   } catch (err) {
     console.error("Error al obtener texto:", err);
     return null;

--- a/src/app/componentes/basicos/usina.js
+++ b/src/app/componentes/basicos/usina.js
@@ -1,4 +1,5 @@
 import { API_URL } from "@/app/config";
+import { normalizeStrapiData, toAbsoluteURL } from "@/app/lib/api";
 
 async function getUsinas() {
   try {
@@ -9,7 +10,7 @@ async function getUsinas() {
       return [];
     }
     const { data } = await res.json();
-    return data;
+    return normalizeStrapiData(data);
   } catch (err) {
     console.error("Error en getUsinas:", err);
     return [];
@@ -26,14 +27,22 @@ export default async function Usina() {
       ) : (
         usinas.map((item) => {
           const { id, nombre, carrera, link, imagen } = item;
-          const imageUrl = imagen?.url ?? '';
+          const imageUrl =
+            toAbsoluteURL(imagen?.url) ||
+            toAbsoluteURL(imagen?.formats?.medium?.url) ||
+            toAbsoluteURL(imagen?.formats?.thumbnail?.url) ||
+            '';
 
           return (
-            <div key={id} className="usina-card" style={{
-                  backgroundImage: `url(${imageUrl})`,
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
-                }}>
+            <div
+              key={id}
+              className="usina-card"
+              style={{
+                backgroundImage: imageUrl ? `url(${imageUrl})` : undefined,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+              }}
+            >
               <div className="usina-contenido">
                 <h2>{nombre}</h2>
                 <p>Carrera: {carrera}</p>

--- a/src/app/lib/api.js
+++ b/src/app/lib/api.js
@@ -6,6 +6,57 @@ export function toAbsoluteURL(path) {
   return `${base}${path}`;
 }
 
+function normalizeAttribute(value) {
+  if (!value) return value;
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeAttribute(item));
+  }
+
+  if (value && typeof value === 'object') {
+    if ('data' in value) {
+      if (Array.isArray(value.data)) {
+        return value.data.map((item) => normalizeStrapiEntity(item));
+      }
+
+      if (value.data === null) {
+        return null;
+      }
+
+      if (value.data) {
+        return normalizeStrapiEntity(value.data);
+      }
+    }
+  }
+
+  return value;
+}
+
+function normalizeStrapiEntity(entity) {
+  if (!entity || typeof entity !== 'object') return entity;
+
+  const { id, attributes } = entity;
+  if (!attributes) return entity;
+
+  const normalized = { id };
+
+  for (const [key, val] of Object.entries(attributes)) {
+    normalized[key] = normalizeAttribute(val);
+  }
+
+  return normalized;
+}
+
+export function normalizeStrapiData(data) {
+  if (!data) return data;
+
+  if (Array.isArray(data)) {
+    return data.map((item) => normalizeStrapiEntity(item));
+  }
+
+  return normalizeStrapiEntity(data);
+}
+
 export async function apiFetch(path, options = {}) {
   const base = process.env.NEXT_PUBLIC_API_URL || '';
   const jwt = typeof window !== 'undefined' ? localStorage.getItem('jwt') : null;


### PR DESCRIPTION
## Summary
- add reusable helpers to normalize Strapi entities and build absolute media URLs
- update agenda, usina and image utilities to read media data from Strapi v4 responses
- return flattened data for texto and acordeon fetchers so consumers no longer access attributes

## Testing
- `npm run lint` *(fails: command prompts for interactive setup and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cc91fd6aa48320be0b31d98eb828ff